### PR TITLE
Update host_list.json

### DIFF
--- a/host_list.json
+++ b/host_list.json
@@ -18,5 +18,5 @@
         ["https://nekko.io/", "https://a.nekko.io/", "nekko.io"],
         ["https://openhost.xyz/", "https://dl.openhost.xyz/", "openhost.xyz"],
         ["https://pomf.is/", "https://u.pomf.is/", "pomf.is"],
-        ["https://pomf.memenet.org/", "https://img.memenet.org/", "pomf.memenet.org"]
+        ["https://pomf.memenet.org/", "https://i.memenet.org/", "pomf.memenet.org"]
 ]


### PR DESCRIPTION
The subdomain used on memenet changed from 'img' to 'i', for url simplicity purposes. I'm a contributor to the website, if you're wondering.