### PR TITLE
Use offline host lists

### DIFF
--- a/limf/cli.py
+++ b/limf/cli.py
@@ -8,16 +8,13 @@ from .hostlist import retrieve_local_host_list
 
 def main():
     """Creates arguments and parses user input"""
-    clone_list = retrieve_local_host_list('host_list.json')  # retrieve_online_host_list()
-    host_string = generate_host_string(clone_list)
-
     parser = argparse.ArgumentParser(
         description='Uploads selected file to working pomf.se clone')
     parser.add_argument('files', metavar='file', nargs='+', type=str,
                         help='Files to upload')
     parser.add_argument('-c', metavar='host number', type=int,
                         dest='host', default=None,
-                        help=host_string)
+                        help='The number (0-n) of the selected host (default is random)')
     parser.add_argument('-l', dest='only_link', action='store_const',
                         const=True, default=False,
                         help='Changes output to just link to the file')
@@ -27,20 +24,20 @@ def main():
     parser.add_argument('-d', dest='decrypt', action='store_const',
                         const=True, default=False,
                         help='Decrypts files from links with encrypted files')
-    parser.add_argument('-j', dest="use_local_list",
-                        default=False,
-                        help='choose to use a local list')
+    parser.add_argument('-j', dest="local_list",
+                        default=False, help='Path to a local list file')
 
     args = parser.parse_args()
-    if args.host and args.host not in range(0, len(clone_list)):
-        print('Please input valid host number')
-        exit()
     try:
-        if args.use_local_list:
-            print("using local list @ {0}".format(args.use_local_list))
-            clone_list = retrieve_local_host_list(args.use_local_list)
+        if args.local_list:
+            clone_list = retrieve_local_host_list(args.local_list)
         else:
             clone_list = retrieve_online_host_list()
+
+        if args.host and not(0 <= args.host < len(clone_list)):
+            print(generate_host_string(clone_list))
+            exit()
+
         parse_arguments(args, clone_list)
     except FileNotFoundError:
         print('Plese enter valid file.')

--- a/limf/cli.py
+++ b/limf/cli.py
@@ -26,6 +26,9 @@ def main():
                         help='Decrypts files from links with encrypted files')
     parser.add_argument('-j', dest="local_list",
                         default=False, help='Path to a local list file')
+    parser.add_argument('-s', dest="show_list", action='store_const',
+                        const=True, default=False,
+                        help='Show the host list (will not upload your files when called)')
 
     args = parser.parse_args()
     try:

--- a/limf/hostlist.py
+++ b/limf/hostlist.py
@@ -19,8 +19,8 @@ def retrieve_local_host_list(local_list_path):
         print("The host list is not valid. Please check it.")
     exit()
 
-def generate_host_string(clone_list):
-    host_string = 'Select hosting: '
+def generate_host_string(clone_list, host_string=None):
+    host_string = host_string or 'Select hosting: '
     for i in range(0, len(clone_list)):
         if i == len(clone_list)-1:
             host_string += '{} - {}'.format(str(i), clone_list[i][2])

--- a/limf/hostlist.py
+++ b/limf/hostlist.py
@@ -1,0 +1,29 @@
+import urllib
+import json
+
+def retrieve_online_host_list():
+    try:
+        url = "https://raw.githubusercontent.com/lich/limf/master/host_list.json"
+        return json.loads(urllib.request.urlopen(url).read().decode('utf-8'))
+    except urllib.error.URLError:
+        print("Check your internet connection.")
+        exit()
+
+def retrieve_local_host_list(local_list_path):
+    try:
+        with open(local_list_path) as host_file:
+            return json.load(host_file)
+    except FileNotFoundError:
+        print("Could not find the given local host list: {0}".format(local_list_path))
+    except json.decoder.JSONDecodeError:
+        print("The host list is not valid. Please check it.")
+    exit()
+
+def generate_host_string(clone_list):
+    host_string = 'Select hosting: '
+    for i in range(0, len(clone_list)):
+        if i == len(clone_list)-1:
+            host_string += '{} - {}'.format(str(i), clone_list[i][2])
+        else:
+            host_string += '{} - {}, '.format(str(i), clone_list[i][2])
+    return host_string

--- a/limf/parse_arguments.py
+++ b/limf/parse_arguments.py
@@ -4,11 +4,18 @@ import random
 from .decrypter import decrypt_files
 from .encrypter import encrypt_files
 from .uploader import upload_files
+from .hostlist import generate_host_string
+
 def parse_arguments(args, clone_list):
     """
     Makes parsing arguments a function.
     """
     host_number = args.host
+
+    if args.show_list:
+        print(generate_host_string(clone_list, "Available hosts: "))
+        exit()
+
     if args.decrypt:
         for i in args.files:
             print(decrypt_files(i))


### PR DESCRIPTION
This PR adds the ability to use an offline list to retrieve the host list.
This addition is useful when you want to use a different set of hosts, or to manually manage the list.

Two new switches are proposed:
* `-j /path/to/host_list.json` to tell `limf` to use an offline list
* `-s` to show the host list. Nothing will be uploaded, encrypted or decrypted when this switch is active.

This behavior is changed:
* The list of the hosts is not available when executing `limf -h`: we have two possible sources (offline or online), but we can't be sure which one we should pick. It's available with `-s`.

This behavior is not changed:
* Online list is still the default: just don't use `-j` switch.

**Couldn't you just download the repository, change the URL of the online list and install?**
It's be an interesting idea, but I don't want to download the list, at all.

----

By the way, **thank you for `limf`**: it's useful and very easy to use.