### PR TITLE
Clean up hosts

### DIFF
--- a/host_list.json
+++ b/host_list.json
@@ -1,10 +1,9 @@
 [
         ["http://1339.cf/", "http://b.1339.cf/", "1339.cf", 104857600, 1],
-        ["http://comfy.moe/", "http://comfy.moe/", "comfy.moe", 2147483648, 1],
+        ["https://comfy.moe/", "https://comfy.moe/", "comfy.moe", 2147483648, 1],
         ["https://cuntflaps.me/", "https://a.cuntflaps.me/", "cuntflaps.me", 209715200, 0],
         ["http://g.zxq.co/", "http://y.zxq.co/", "zxq.co", 52428800, 1],
         ["http://glop.me/", "http://gateway.glop.me/ipfs/", "glop.me (IPFS!)", 10485760, 0],
-        ["http://nigger.cat/", "http://a.nigger.cat/", "nigger.cat", 52428800, 1],
         ["http://up.che.moe/", "http://cdn.che.moe/", "up.che.moe", 52428800, 1],
         ["https://cocaine.ninja/", "https://a.cocaine.ninja/",  "cocaine.ninja", 104857600, 1],
         ["https://kyaa.sg/", "https://r.kyaa.sg/", "kyaa.sg", 104857600, 0],
@@ -15,8 +14,6 @@
         ["https://desu.sh/", "https://a.desu.sh/", "desu.sh", 2147483648, 1],
         ["https://u.aww.moe/", "https://u.aww.moe/", "aww.moe", 2147483648, 1],
         ["https://pomf.lesderid.net/", "https://pomf.lesderid.net/f/", "pomf.lesderid.net", 52428800, 1],
-        ["https://steamy.moe/", "https://ln.steamy.moe/", "steamy.moe", 536870912, 1],
         ["https://pomf.amatsuka.com/", "https://pomf.amatsuka.com/a/", "pomf.amatsuka.com", 524288000, 1],
-        ["http://qt.cx/", "http://z.qt.cx/", "qt.cx", 52428800, 1],
         ["https://p.fuwafuwa.moe/", "https://p.fuwafuwa.moe/", "p.fuwafuwa.moe", 52428800, 1]
 ]


### PR DESCRIPTION
nigger.cat and qt.cx seem to have died.
comfy.moe moved to https.
steamy.moe returns an error when trying to upload any kind of file.