### PR TITLE
Remove pomf.lesderid.net and update p.fuwafuwa.moe

### DIFF
--- a/host_list.json
+++ b/host_list.json
@@ -13,7 +13,6 @@
         ["https://sugoi.vidyagam.es/", "https://sugoi.vidyagam.es/qt/", "sugoi.vidyagam.es", 104857600, 0],
         ["https://desu.sh/", "https://a.desu.sh/", "desu.sh", 2147483648, 1],
         ["https://aww.moe/", "https://aww.moe/", "aww.moe", 2147483648, 1],
-        ["https://pomf.lesderid.net/", "https://pomf.lesderid.net/f/", "pomf.lesderid.net", 52428800, 1],
         ["https://pomf.amatsuka.com/", "https://pomf.amatsuka.com/a/", "pomf.amatsuka.com", 524288000, 1],
-        ["https://p.fuwafuwa.moe/", "https://p.fuwafuwa.moe/", "p.fuwafuwa.moe", 52428800, 1]
+        ["https://p.fuwafuwa.moe/", "https://p.fuwafuwa.moe/", "p.fuwafuwa.moe", 268435456, 1]
 ]


### PR DESCRIPTION
pomf.lesderid.net has been deprecated for a while. It still works, but it 
may stop working in the future.

p.fuwafuwa.moe now has an upload limit of 256MiB.