### PR TITLE
Update host_list.json

### DIFF
--- a/host_list.json
+++ b/host_list.json
@@ -4,6 +4,7 @@
         ["http://g.zxq.co/", "http://y.zxq.co/", "zxq.co", 52428800, 1],
         ["http://glop.me/", "http://gateway.glop.me/ipfs/", "glop.me (IPFS!)", 10485760, 0],
         ["http://up.che.moe/", "http://cdn.che.moe/", "up.che.moe", 52428800, 1],
+        ["https://cocaine.ninja/", "https://a.cocaine.ninja/",  "cocaine.ninja", 104857600, 1],
         ["https://kyaa.sg/", "https://r.kyaa.sg/", "kyaa.sg", 104857600, 0],
         ["https://mixtape.moe/", "https://my.mixtape.moe/", "mixtape.moe", 104857600, 0],
         ["https://pomf.cat/", "https://a.pomf.cat/", "pomf.cat", 78643200, 0],
@@ -11,4 +12,5 @@
         ["https://sugoi.vidyagam.es/", "https://sugoi.vidyagam.es/qt/", "sugoi.vidyagam.es", 104857600, 0],
         ["https://desu.sh/", "https://a.desu.sh/", "desu.sh", 2147483648, 1],
         ["https://aww.moe/", "https://aww.moe/", "aww.moe", 2147483648, 1],
+        ["https://p.fuwafuwa.moe/", "https://p.fuwafuwa.moe/", "p.fuwafuwa.moe", 268435456, 1]
 ]

--- a/host_list.json
+++ b/host_list.json
@@ -1,11 +1,9 @@
 [
-        ["http://1339.cf/", "http://b.1339.cf/", "1339.cf", 104857600, 1],
         ["https://comfy.moe/", "https://comfy.moe/", "comfy.moe", 2147483648, 1],
         ["https://cuntflaps.me/", "https://a.cuntflaps.me/", "cuntflaps.me", 209715200, 0],
         ["http://g.zxq.co/", "http://y.zxq.co/", "zxq.co", 52428800, 1],
         ["http://glop.me/", "http://gateway.glop.me/ipfs/", "glop.me (IPFS!)", 10485760, 0],
         ["http://up.che.moe/", "http://cdn.che.moe/", "up.che.moe", 52428800, 1],
-        ["https://cocaine.ninja/", "https://a.cocaine.ninja/",  "cocaine.ninja", 104857600, 1],
         ["https://kyaa.sg/", "https://r.kyaa.sg/", "kyaa.sg", 104857600, 0],
         ["https://mixtape.moe/", "https://my.mixtape.moe/", "mixtape.moe", 104857600, 0],
         ["https://pomf.cat/", "https://a.pomf.cat/", "pomf.cat", 78643200, 0],
@@ -13,6 +11,4 @@
         ["https://sugoi.vidyagam.es/", "https://sugoi.vidyagam.es/qt/", "sugoi.vidyagam.es", 104857600, 0],
         ["https://desu.sh/", "https://a.desu.sh/", "desu.sh", 2147483648, 1],
         ["https://aww.moe/", "https://aww.moe/", "aww.moe", 2147483648, 1],
-        ["https://pomf.amatsuka.com/", "https://pomf.amatsuka.com/a/", "pomf.amatsuka.com", 524288000, 1],
-        ["https://p.fuwafuwa.moe/", "https://p.fuwafuwa.moe/", "p.fuwafuwa.moe", 268435456, 1]
 ]


### PR DESCRIPTION
1339.cf domain has been hijacked.
cocaine.ninja is dead. (back up)
pomf.amatsuka.com was intentionally removed, it seems.
p.fuwafuwa.moe is down. Paying attention to when it comes back. (back up)